### PR TITLE
FormatDuration Now Includes Days

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For any further question, you can use the [forum](https://groups.google.com/d/fo
 * [PascalSchumacher](https://github.com/PascalSchumacher)
 * [Toilal](https://github.com/Toilal)
 * [xenji](https://github.com/xenji)
+* [ipropper](https://github.com/ipropper)
 
 Thank you all for your contributions!
 

--- a/easybatch-core/src/main/java/org/easybatch/core/util/Utils.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/util/Utils.java
@@ -56,7 +56,7 @@ public abstract class Utils {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd hh:mm:ss";
 
-    public static final String DURATION_FORMAT = "%shr %smin %ssec %sms";
+    public static final String DURATION_FORMAT = "%sd %shr %smin %ssec %sms";
 
     public static final String NOT_APPLICABLE = "N/A";
 
@@ -92,7 +92,8 @@ public abstract class Utils {
     }
 
     public static String formatDuration(long duration) {
-        return String.format(DURATION_FORMAT, MILLISECONDS.toHours(duration) % 24, MILLISECONDS.toMinutes(duration) % 60, MILLISECONDS.toSeconds(duration) % 60, duration % 1000);
+        return String.format(DURATION_FORMAT, MILLISECONDS.toDays(duration), MILLISECONDS.toHours(duration) % 24,
+                MILLISECONDS.toMinutes(duration) % 60, MILLISECONDS.toSeconds(duration) % 60, duration % 1000);
     }
 
     public static String formatErrorThreshold(final long errorThreshold) {

--- a/easybatch-core/src/test/java/org/easybatch/core/job/DefaultJobReportFormatterTest.java
+++ b/easybatch-core/src/test/java/org/easybatch/core/job/DefaultJobReportFormatterTest.java
@@ -81,7 +81,7 @@ public class DefaultJobReportFormatterTest {
                 "Metrics:" + LINE_SEPARATOR +
                 "\tStart time = 2015-01-01 01:00:00" + LINE_SEPARATOR +
                 "\tEnd time = 2015-01-01 01:00:10" + LINE_SEPARATOR +
-                "\tDuration = 0hr 0min 10sec 0ms" + LINE_SEPARATOR +
+                "\tDuration = 0d 0hr 0min 10sec 0ms" + LINE_SEPARATOR +
                 "\tRead count = 0" + LINE_SEPARATOR +
                 "\tWrite count = 0" + LINE_SEPARATOR +
                 "\tFiltered count = 0" + LINE_SEPARATOR +

--- a/easybatch-core/src/test/java/org/easybatch/core/util/UtilsTest.java
+++ b/easybatch-core/src/test/java/org/easybatch/core/util/UtilsTest.java
@@ -59,10 +59,13 @@ public class UtilsTest {
 
     @Test
     public void testFormatDuration() throws Exception {
-        assertThat(Utils.formatDuration(100)).isEqualTo("0hr 0min 0sec 100ms");
-        assertThat(Utils.formatDuration(1000)).isEqualTo("0hr 0min 1sec 0ms");
-        assertThat(Utils.formatDuration(60 * 2 * 1000)).isEqualTo("0hr 2min 0sec 0ms");
-        assertThat(Utils.formatDuration(60 * 60 * 2 * 1000)).isEqualTo("2hr 0min 0sec 0ms");
+        assertThat(Utils.formatDuration(100)).isEqualTo("0d 0hr 0min 0sec 100ms");
+        assertThat(Utils.formatDuration(1000)).isEqualTo("0d 0hr 0min 1sec 0ms");
+        assertThat(Utils.formatDuration(60 * 2 * 1000)).isEqualTo("0d 0hr 2min 0sec 0ms");
+        assertThat(Utils.formatDuration(60 * 60 * 2 * 1000)).isEqualTo("0d 2hr 0min 0sec 0ms");
+        assertThat(Utils.formatDuration((24 * 60 * 60 * 2 * 1000))).isEqualTo("2d 0hr 0min 0sec 0ms");
+        // in the extremely unlikely event that the job takes more than a year
+        assertThat(Utils.formatDuration(31622400000L)).isEqualTo("366d 0hr 0min 0sec 0ms");
     }
 
     @Test

--- a/easybatch-tools/src/test/resources/org/easybatch/tools/reporting/expectedReport.html
+++ b/easybatch-tools/src/test/resources/org/easybatch/tools/reporting/expectedReport.html
@@ -40,7 +40,7 @@
                 </tr>
                 <tr>
                     <td>Duration</td>
-                    <td>0hr 0min 10sec 0ms</td>
+                    <td>0d 0hr 0min 10sec 0ms</td>
                 </tr>
                 <tr>
                     <td>Status</td>


### PR DESCRIPTION
Altered the formatDuration code so that it includes days. Jobs that take over 24 hours will now properly display the total time. There is no cap on the total length of the duration.