### PR TITLE
First commit new multi-thread component and simple implementation.

### DIFF
--- a/easybatch-core/src/main/java/org/easybatch/core/job/ForkJoin.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/job/ForkJoin.java
@@ -1,0 +1,117 @@
+package org.easybatch.core.job;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.easybatch.core.jmx.JobMonitorProxy;
+import org.easybatch.core.jmx.JobMonitoringListener;
+import org.easybatch.core.record.Record;
+
+/**
+ * Base structure to create a multi-thread job. The user provide the number of
+ * thread in which will be split the principal job and the implementation of
+ * three task: "fork job", "workers job" and "join job". The number of threads
+ * created is equal the number provided more two, that are the fork and join
+ * job. Is returned a list of {@link JobReport}
+ * 
+ * @author Somma Daniele
+ */
+public abstract class ForkJoin {
+
+  private static final String DEFAULT_HOST = "localhost";
+  private static final int    DEFAULT_PORT = 9999;
+
+  private final int           threadPoolSize;
+  private final int           nWorkQueue;
+  private final int           nPoisonRecord;
+  private final String        name;
+  private final boolean       jmx;
+
+  private Job                 forkJob;
+  private List<Job>           workersJob;
+  private Job                 joinJob;
+  private List<Thread>        jobMonitoringListener;
+
+  protected ForkJoin(String name, int threadPoolSize, boolean jmx) {
+    this(name, threadPoolSize, jmx, DEFAULT_HOST, DEFAULT_PORT);
+  }
+
+  protected ForkJoin(String name, int threadPoolSize, boolean jmx, String host, int port) {
+    super();
+    this.nWorkQueue = threadPoolSize;
+    this.threadPoolSize = threadPoolSize + 2;
+    this.nPoisonRecord = threadPoolSize;
+    this.name = name;
+    this.jmx = jmx;
+
+    setup(host, port);
+  }
+
+  private void setup(String host, int port) {
+    BlockingQueue<Record> joinQueue = new LinkedBlockingQueue<>();
+    List<BlockingQueue<Record>> workQueues = new ArrayList<>(nWorkQueue);
+    workersJob = new ArrayList<>(nWorkQueue);
+    if (jmx) {
+      jobMonitoringListener = new ArrayList<>(nWorkQueue);
+    }
+    for (int i = 0; i < nWorkQueue; i++) {
+      BlockingQueue<Record> workQueue = new LinkedBlockingQueue<>();
+      workQueues.add(workQueue);
+      String jobName = name + "-thread-" + (i + 1);
+      workersJob.add(buildWorkerJob(jobName, workQueue, joinQueue, nWorkQueue, jmx));
+      // A job monitor proxy for each workers...
+      if (jmx) {
+        jobMonitoringListener.add(buildJobMonitoringListener(host, port, jobName));
+      }
+    }
+    forkJob = buildForkJob(name + "-fork-job", workQueues);
+    joinJob = buildJoinJob(name + "-join-job", joinQueue, nPoisonRecord);
+  }
+
+  private Thread buildJobMonitoringListener(String host, int port, String jobName) {
+    JobMonitorProxy jm = new JobMonitorProxy(host, port, jobName);
+    for (JobMonitoringListener jml : buildJobMonitoringListeners()) {
+      jm.addMonitoringListener(jml);
+    }
+
+    Thread thread = new Thread(jm);
+    thread.setDaemon(true);
+    return thread;
+  }
+
+  private void startJobMonitoringListener() {
+    for (Thread thread : jobMonitoringListener) {
+      thread.start();
+    }
+  }
+
+  public List<Future<JobReport>> run() {
+    if (jmx) {
+      startJobMonitoringListener();
+    }
+
+    // Create executor and submit jobs in parallel...
+    JobExecutor je = new JobExecutor(threadPoolSize);
+    List<Job> jobToSubmit = new LinkedList<>();
+    jobToSubmit.add(forkJob);
+    jobToSubmit.addAll(workersJob);
+    jobToSubmit.add(joinJob);
+    List<Future<JobReport>> jobsReport = je.submitAll(jobToSubmit);
+    je.shutdown();
+    return jobsReport;
+  }
+
+  protected abstract Job buildForkJob(final String jobName, final List<BlockingQueue<Record>> workQueues);
+
+  protected abstract Job buildWorkerJob(final String jobName, final BlockingQueue<Record> workQueue, final BlockingQueue<Record> joinQueue, int batchSize,
+      boolean jmx);
+
+  protected abstract Job buildJoinJob(final String jobName, final BlockingQueue<Record> joinQueue, final int nPoisonRecord);
+
+  protected abstract List<JobMonitoringListener> buildJobMonitoringListeners();
+
+}

--- a/easybatch-core/src/main/java/org/easybatch/core/job/SimplifiedForkJoin.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/job/SimplifiedForkJoin.java
@@ -1,0 +1,70 @@
+package org.easybatch.core.job;
+
+import static org.easybatch.core.job.JobBuilder.aNewJob;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+
+import org.easybatch.core.filter.PoisonRecordFilter;
+import org.easybatch.core.jmx.JobMonitoringListener;
+import org.easybatch.core.listener.PoisonRecordBroadcaster;
+import org.easybatch.core.reader.BlockingQueueRecordReader;
+import org.easybatch.core.record.Record;
+import org.easybatch.core.writer.BlockingQueueRecordWriter;
+import org.easybatch.core.writer.RoundRobinBlockingQueueRecordWriter;
+
+/**
+ * Simply and common configuration of multi-thread job. The three principal job
+ * are created with a base configuration where records are splitted in
+ * "BlockingQueue", one for each "workers job". "Fork job" add in each queue a
+ * "Poison record" at the end. "Workers job" process the record in the queues
+ * and write the record in the join queue, "Join job" filter/remove the "Poison
+ * record". User must decorate the base configuration providing readers,
+ * mappers, listeners, writers, ecc, ecc. Important point is the filters in
+ * "workers job" must preserve the "Poison record" in the queue.
+ * 
+ * @author Somma Daniele
+ */
+public abstract class SimplifiedForkJoin extends ForkJoin {
+
+  protected SimplifiedForkJoin(String name, int threadPoolSize, boolean jmx) {
+    super(name, threadPoolSize, jmx);
+  }
+
+  @Override
+  protected Job buildForkJob(String jobName, List<BlockingQueue<Record>> workQueues) {
+    JobBuilder jb = aNewJob().named(jobName);
+    builderForkJob(jb);
+    return jb.writer(new RoundRobinBlockingQueueRecordWriter(workQueues)).jobListener(new PoisonRecordBroadcaster(workQueues)).build();
+  }
+
+  @Override
+  protected Job buildWorkerJob(String jobName, BlockingQueue<Record> workQueue, BlockingQueue<Record> joinQueue, int batchSize, boolean jmx) {
+    JobBuilder jb = aNewJob().named(jobName).batchSize(batchSize);
+    if (jmx) {
+      jb.enableJmx();
+    }
+    jb.reader(new BlockingQueueRecordReader(workQueue));
+    builderWorkerJob(jb);
+    return jb.writer(new BlockingQueueRecordWriter(joinQueue)).build();
+  }
+
+  @Override
+  protected Job buildJoinJob(String jobName, BlockingQueue<Record> joinQueue, int nPoisonRecord) {
+    JobBuilder jb = aNewJob().named(jobName).reader(new BlockingQueueRecordReader(joinQueue, nPoisonRecord)).filter(new PoisonRecordFilter());
+    builderJoinJob(jb);
+    return jb.build();
+  }
+
+  @Override
+  protected List<JobMonitoringListener> buildJobMonitoringListeners() {
+    return null;
+  }
+
+  public abstract void builderForkJob(JobBuilder jobBuilder);
+
+  public abstract void builderWorkerJob(JobBuilder jobBuilder);
+
+  public abstract void builderJoinJob(JobBuilder jobBuilder);
+
+}


### PR DESCRIPTION
Starting from your tutorial **Processing data in parallel**, I generalized the solution to allow the user to easily create a multi-thread job. Starting from the base structure provided from **ForkJoin** class, the user must provide the number of threads want create to process the work and the implementation for methods that create the three macro jobs: fork-job, workers-job and join-job. The user could also choose to enable JMX monitoring and provide custom listener.
To simplified the use that match your tutorial, I also created a simple implementation represent into **SimplifiedForkJoin** class. Here the base operations like dispatch the records in the queues, add and remove Poison records, read and write from the queues are provided out of the box. Extending this class, the user customize the three macro jobs adding new components at each JobBuilder.
At the moment the flow work well but exist two issues:
1. If I choose to enable JMX monitoring and I create more than four thread, randomically the creation of some JobMonitorProxy fail with this error:
`...org.easybatch.core.jmx.JobMonitorProxy run
SCHWERWIEGEND: Unable to listen to job monitoring notifications
javax.management.InstanceNotFoundException: org.easybatch.core.monitor:name=...`
I haven't found a solution.

2. I haven't found an easily way to create a basic "progress listener" could be enable to show the progress of each workers-job and/or all ForkJoin job.

I saw only in second instance that also you started to develop a branch to introduce this function, you adopt different approach but we share some points. Maybe we can works to merge both solution in one.