### PR TITLE
allow error threshold to be zero

### DIFF
--- a/easybatch-core/src/main/java/org/easybatch/core/job/JobBuilder.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/job/JobBuilder.java
@@ -166,8 +166,8 @@ public final class JobBuilder {
      * @return the job builder
      */
     public JobBuilder errorThreshold(final long errorThreshold) {
-        if (errorThreshold < 1) {
-            throw new IllegalArgumentException("error threshold must be >= 1");
+        if (errorThreshold < 0) {
+            throw new IllegalArgumentException("error threshold must be >= 0");
         }
         parameters.setErrorThreshold(errorThreshold);
         return this;

--- a/easybatch-core/src/test/java/org/easybatch/core/job/JobBuilderTest.java
+++ b/easybatch-core/src/test/java/org/easybatch/core/job/JobBuilderTest.java
@@ -33,7 +33,7 @@ public class JobBuilderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void whenErrorThresholdIsLessThanOne_thenShouldThrowAnIllegalArgumentException() throws Exception {
-        JobBuilder.aNewJob().errorThreshold(0);
+    public void whenErrorThresholdIsLessThanZero_thenShouldThrowAnIllegalArgumentException() throws Exception {
+        JobBuilder.aNewJob().errorThreshold(-1);
     }
 }


### PR DESCRIPTION
Allow an error threshold of zero to be set when building a job. This is useful in cases where you want the batch to fail after a single error, which was not previously possible.

Fixes #320