### PR TITLE
efficient-report-metrics-merge

### DIFF
--- a/easybatch-core/src/main/java/org/easybatch/core/job/DefaultJobReportMerger.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/job/DefaultJobReportMerger.java
@@ -94,9 +94,7 @@ public class DefaultJobReportMerger implements JobReportMerger {
     }
 
     private void calculateReadRecords(JobReport finalJobReport, JobReport jobReport) {
-        for (int i = 0; i < jobReport.getMetrics().getReadCount(); i++) {
-            finalJobReport.getMetrics().incrementReadCount();
-        }
+        finalJobReport.getMetrics().incrementReadCount(jobReport.getMetrics().getReadCount());
     }
 
     private void calculateWrittenRecords(JobReport finalJobReport, JobReport jobReport) {
@@ -104,15 +102,11 @@ public class DefaultJobReportMerger implements JobReportMerger {
     }
 
     private void calculateErrorRecords(JobReport finalJobReport, JobReport jobReport) {
-        for (int i = 0; i < jobReport.getMetrics().getErrorCount(); i++) {
-            finalJobReport.getMetrics().incrementErrorCount();
-        }
+        finalJobReport.getMetrics().incrementErrorCount(jobReport.getMetrics().getErrorCount());
     }
 
     private void calculateFilteredRecords(JobReport finalJobReport, JobReport jobReport) {
-        for (int i = 0; i < jobReport.getMetrics().getFilterCount(); i++) {
-            finalJobReport.getMetrics().incrementFilterCount();
-        }
+        finalJobReport.getMetrics().incrementFilterCount(jobReport.getMetrics().getFilterCount());
     }
 
     private String concatenate(List<String> names) {

--- a/easybatch-core/src/main/java/org/easybatch/core/job/JobMetrics.java
+++ b/easybatch-core/src/main/java/org/easybatch/core/job/JobMetrics.java
@@ -52,12 +52,24 @@ public class JobMetrics implements Serializable {
         filterCount++;
     }
 
+    public void incrementFilterCount(long count) {
+        filterCount += count;
+    }
+
     public void incrementErrorCount() {
         errorCount++;
     }
 
+    public void incrementErrorCount(long count) {
+        errorCount += count;
+    }
+
     public void incrementReadCount() {
         readCount++;
+    }
+
+    public void incrementReadCount(long count) {
+        readCount += count;
     }
 
     public void incrementWriteCount(long count) {

--- a/easybatch-core/src/test/java/org/easybatch/core/job/DefaultJobReportMergerTest.java
+++ b/easybatch-core/src/test/java/org/easybatch/core/job/DefaultJobReportMergerTest.java
@@ -41,7 +41,7 @@ public class DefaultJobReportMergerTest {
     }
 
     @Test
-    public void testReportsMerging() throws Exception {
+    public void testReportsMerging() {
 
         Properties systemProperties = new Properties();
         JobMetrics metrics1 = new JobMetrics();
@@ -96,6 +96,5 @@ public class DefaultJobReportMergerTest {
         // job name is the concatenation of partial job names
         assertThat(finalJobReport.getJobName()).isEqualTo("job1|job2");
         assertThat(finalJobReport.getSystemProperties()).isEqualTo(systemProperties);
-
     }
 }

--- a/easybatch-core/src/test/java/org/easybatch/core/job/JobMetricsTest.java
+++ b/easybatch-core/src/test/java/org/easybatch/core/job/JobMetricsTest.java
@@ -1,0 +1,91 @@
+package org.easybatch.core.job;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for {@link JobMetrics}
+ *
+ * @author verdi8 (https://github.com/verdi8)
+ */
+public class JobMetricsTest {
+
+    private JobMetrics jobMetrics;
+
+    @Before
+    public void setUp() throws Exception {
+        jobMetrics = new JobMetrics();
+    }
+
+    @Test
+    public void testFilterCount() {
+        assertThat(jobMetrics.getFilterCount()).isEqualTo(0);
+        jobMetrics.incrementFilterCount();
+        jobMetrics.incrementFilterCount();
+        assertThat(jobMetrics.getFilterCount()).isEqualTo(2);
+        jobMetrics.incrementFilterCount(5);
+        jobMetrics.incrementFilterCount(3);
+        assertThat(jobMetrics.getFilterCount()).isEqualTo(10);
+    }
+
+    @Test
+    public void testErrorCount() {
+        assertThat(jobMetrics.getErrorCount()).isEqualTo(0);
+        jobMetrics.incrementErrorCount();
+        jobMetrics.incrementErrorCount();
+        jobMetrics.incrementErrorCount();
+        assertThat(jobMetrics.getErrorCount()).isEqualTo(3);
+        jobMetrics.incrementErrorCount(7);
+        jobMetrics.incrementErrorCount(5);
+        assertThat(jobMetrics.getErrorCount()).isEqualTo(15);
+    }
+
+    @Test
+    public void testReadCount() {
+        assertThat(jobMetrics.getReadCount()).isEqualTo(0);
+        jobMetrics.incrementReadCount(3);
+        jobMetrics.incrementReadCount(4);
+        assertThat(jobMetrics.getReadCount()).isEqualTo(7);
+        jobMetrics.incrementReadCount();
+        jobMetrics.incrementReadCount();
+        jobMetrics.incrementReadCount();
+        assertThat(jobMetrics.getReadCount()).isEqualTo(10);
+    }
+
+    @Test
+    public void testWriteCount() {
+        assertThat(jobMetrics.getWriteCount()).isEqualTo(0);
+        jobMetrics.incrementWriteCount(11);
+        jobMetrics.incrementWriteCount(9);
+        assertThat(jobMetrics.getWriteCount()).isEqualTo(20);
+    }
+
+    @Test
+    public void testStartEndTimesAndDuration() {
+        assertThat(jobMetrics.getStartTime()).isEqualTo(0);
+        assertThat(jobMetrics.getEndTime()).isEqualTo(0);
+        assertThat(jobMetrics.getDuration()).isEqualTo(0);
+
+        long expectedStartTime = System.currentTimeMillis();
+        long expectedEndTime = expectedStartTime + 12543;
+        jobMetrics.setStartTime(expectedStartTime);
+        jobMetrics.setEndTime(expectedEndTime);
+
+        assertThat(jobMetrics.getStartTime()).isEqualTo(expectedStartTime);
+        assertThat(jobMetrics.getEndTime()).isEqualTo(expectedEndTime);
+        assertThat(jobMetrics.getDuration()).isEqualTo(12543);
+    }
+
+    @Test
+    public void testCustomMetrics() {
+        assertThat(jobMetrics.getCustomMetrics().isEmpty()).isTrue();
+        jobMetrics.addMetric("metric1", 987654321L);
+        jobMetrics.addMetric("metric2", "aValue");
+        assertThat(jobMetrics.getCustomMetrics().size()).isEqualTo(2);
+        assertThat(jobMetrics.getCustomMetrics().get("metric1")).isEqualTo(987654321L);
+        assertThat(jobMetrics.getCustomMetrics().get("metric2")).isEqualTo("aValue");
+    }
+
+}


### PR DESCRIPTION
Efficiently merges report metrics avoiding unnecessary increment loops.
Closes #338.